### PR TITLE
Ocultar tabBar en AgregarTarjetaPage y simplificar navegación

### DIFF
--- a/FinanKey/AppShell.xaml.cs
+++ b/FinanKey/AppShell.xaml.cs
@@ -18,8 +18,19 @@ namespace FinanKey
             AddTab(typeof(ConfiguracionesPage), PageType.ConfiguracionPage);
 
             Loaded += AppShellLoaded;
+            //Sucribir el evento OnShellNavigated
+            this.Navigated += OnShellNavigated;
         }
 
+        private void OnShellNavigated(object? sender, ShellNavigatedEventArgs e)
+        {
+            var rutaActual = e.Current.Location.OriginalString;
+            if (rutaActual.Contains(nameof(AgregarTarjetaPage)))
+            {
+                tabBar.IsVisible = false;
+                tabBarView.SetVisible(false);
+            }
+        }
 
         private static void AppShellLoaded(object sender, EventArgs e)
         {
@@ -39,7 +50,6 @@ namespace FinanKey
 
             tabBar.Items.Add(tab);
         }
-
         private void TabBarViewCurrentPageChanged(object sender, TabBarEventArgs e)
         {
             Shell.Current.GoToAsync("///" + e.CurrentPage.ToString());

--- a/FinanKey/MauiProgram.cs
+++ b/FinanKey/MauiProgram.cs
@@ -9,7 +9,7 @@ using FinanKey.Datos;
 using SimpleToolkit.SimpleShell;
 using SimpleToolkit.Core;
 using FinanKey.View.Behaviors;
-
+using FinanKey.View.Controles;
 namespace FinanKey
 {
     public static class MauiProgram
@@ -73,8 +73,10 @@ namespace FinanKey
             builder.Services.AddSingleton<IServiciosTransaccionGasto, ContextoDatosGasto>();
             builder.Services.AddSingleton<IServicioTransaccionCuenta, ContextoDatosCuenta>();
             builder.Services.AddSingleton<IServicioTarjeta, ServicioTarjeta>();
-
+            //Registrar comportamiento personalizado
             builder.Services.AddSingleton<SfRadioButtonStateChangedBehavior>();
+            //Registrar el Shell de la aplicación
+            builder.Services.AddSingleton<TabBarView>();
 
 #if DEBUG
             builder.Logging.AddDebug();

--- a/FinanKey/View/AgregarTarjetaPage.xaml.cs
+++ b/FinanKey/View/AgregarTarjetaPage.xaml.cs
@@ -1,16 +1,32 @@
 using FinanKey.ViewModels;
+using FinanKey.View.Controles;
 
 namespace FinanKey.View;
 
 public partial class AgregarTarjetaPage : ContentPage
 {
-    //Inyección de dependencias para los ViewModels
-    public AgregarTarjetaPage(ViewModelTarjeta viewModelTarjeta)
+    //Inyección de dependencias
+    private readonly TabBarView _tabBarView;
+    public AgregarTarjetaPage(ViewModelTarjeta viewModelTarjeta, TabBarView tabBarView)
 	{
 		InitializeComponent();
+        _tabBarView = tabBarView;
         BindingContext = viewModelTarjeta;
     }
 
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _tabBarView.IsVisible = false;
+        _tabBarView.SetVisible(false);
+
+    }
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _tabBarView.IsVisible = true;
+        _tabBarView.SetVisible(true);
+    }
     private void OnEntryFocused(Border border)
     {
         border.Stroke = App.Current?.Resources["ColorAzulMarino"] as Color;
@@ -37,7 +53,6 @@ public partial class AgregarTarjetaPage : ContentPage
     {
 
     }
-
     private void entradaDescripcion_Focused(object sender, FocusEventArgs e) => OnEntryFocused(borderDescripcion);
 
     private void entradaDescripcion_Unfocused(object sender, FocusEventArgs e) =>OnEntryUnfocused(borderDescripcion);

--- a/FinanKey/ViewModels/ViewModelInicio.cs
+++ b/FinanKey/ViewModels/ViewModelInicio.cs
@@ -4,6 +4,7 @@ using FinanKey.Models;
 using FinanKey.Servicios;
 using FinanKey.View;
 using System.Collections.ObjectModel;
+using FinanKey.View.Controles;
 
 namespace FinanKey.ViewModels
 {
@@ -11,6 +12,7 @@ namespace FinanKey.ViewModels
     {
         //Inyección de dependencias 
         public readonly IServicioTarjeta _servicioTarjeta;
+        private readonly TabBarView _tabBarView;
         //Inicializar la lista de cuentas como una colección observable
         [ObservableProperty]
         private ObservableCollection<Tarjeta> _listaTarjetas = new();
@@ -22,10 +24,11 @@ namespace FinanKey.ViewModels
         [ObservableProperty]
         private bool _hayMovimientos = true;
 
-        public ViewModelInicio(IServicioTarjeta servicioTarjeta)
+        public ViewModelInicio(IServicioTarjeta servicioTarjeta, TabBarView tabBarView)
         {
             //Asignar los servicios a las variables privadas
             _servicioTarjeta = servicioTarjeta;
+            _tabBarView = tabBarView;
         }
         //Metodo para cargar las cuentas desde la base de datos
         public async Task CargarTarjetasAsync()
@@ -69,6 +72,8 @@ namespace FinanKey.ViewModels
         [RelayCommand]
         public async Task NavegarAgregarTarjeta()
         {
+            _tabBarView.IsVisible = false;
+            _tabBarView.SetVisible(false);
             await Shell.Current.GoToAsync(nameof(AgregarTarjetaPage));
         }
     }


### PR DESCRIPTION
Se ha añadido el evento `OnShellNavigated` en `AppShell.xaml.cs` para ocultar la barra de pestañas al navegar a `AgregarTarjetaPage`, mejorando la experiencia del usuario. Se eliminó el método `TabBarViewCurrentPageChanged` para simplificar la lógica de navegación.

Además, se registró `TabBarView` como un servicio singleton en `MauiProgram.cs`. En `AgregarTarjetaPage.xaml.cs`, se modificó el constructor para incluir `TabBarView` y se añadieron métodos para gestionar su visibilidad al aparecer y desaparecer la página. Por último, en `ViewModelInicio.cs`, se incorporó `TabBarView` como un campo privado para controlar su visibilidad durante la navegación.